### PR TITLE
feat: high-priority UI/UX improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,9 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
 
 @layer utilities {
   .text-balance {
@@ -104,6 +101,18 @@ body {
 [data-chart] .recharts-polar-grid [stroke="#ccc"],
 [data-chart] .recharts-reference-line [stroke="#ccc"] {
   stroke: hsl(var(--border));
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Custom prose styling for blog posts */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,9 +32,15 @@ export default function RootLayout({
         )}
       >
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-ring"
+          >
+            Skip to main content
+          </a>
           <Nav />
           <CommandMenu />
-          {children}
+          <div id="main-content">{children}</div>
           <SpeedInsights />
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,45 +1,96 @@
-'use client'
-
-import { Button } from '@/components/ui/button'
-import { motion } from 'motion/react'
+import { ArrowRight, BookOpen, Briefcase, Code2 } from 'lucide-react'
 import Link from 'next/link'
-import { TypeAnimation } from 'react-type-animation'
+import { HeroSection } from '@/components/hero-section'
+import { Separator } from '@/components/ui/separator'
+import { getSortedPostsData } from '@/lib/blog'
+import { formatRelativeTime } from '@/lib/utils'
 
 export default function Home() {
+  const recentPosts = getSortedPostsData().slice(0, 3)
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="text-center"
-      >
-        <h1 className="text-4xl font-bold mb-4">Welcome to My Portfolio</h1>
-        <div className="h-20 mb-8">
-          {' '}
-          <TypeAnimation
-            sequence={[
-              'A modern and minimal showcase of my work',
-              2000,
-              'Bringing ideas to life through code',
-              2000,
-              'Crafting digital experiences with passion',
-              2000,
-              'Innovating at the intersection of design and technology',
-              2000,
-            ]}
-            wrapper="p"
-            speed={50}
-            className="text-xl"
-            repeat={Number.POSITIVE_INFINITY}
-          />
-        </div>
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Button asChild variant="outline">
-            <Link href="/blog">Read Blog</Link>
-          </Button>
-        </div>
-      </motion.div>
+    <main className="min-h-screen">
+      {/* Hero */}
+      <HeroSection />
+
+      {/* Content sections */}
+      <div className="container mx-auto px-4 max-w-2xl pb-16">
+        {/* Quick links */}
+        <section className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-12">
+          <Link
+            href="/about"
+            className="group flex items-center gap-3 rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
+          >
+            <Briefcase className="h-4 w-4 text-muted-foreground shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium">About</p>
+              <p className="text-xs text-muted-foreground">Background & experience</p>
+            </div>
+          </Link>
+          <Link
+            href="/uses"
+            className="group flex items-center gap-3 rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
+          >
+            <Code2 className="h-4 w-4 text-muted-foreground shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Uses</p>
+              <p className="text-xs text-muted-foreground">Tools & tech stack</p>
+            </div>
+          </Link>
+          <Link
+            href="/blog"
+            className="group flex items-center gap-3 rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
+          >
+            <BookOpen className="h-4 w-4 text-muted-foreground shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Blog</p>
+              <p className="text-xs text-muted-foreground">Writing & thoughts</p>
+            </div>
+          </Link>
+        </section>
+
+        <Separator className="mb-12" />
+
+        {/* Recent posts */}
+        <section>
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-sm font-medium text-muted-foreground">Recent posts</h2>
+            <Link
+              href="/blog"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              View all
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+          <div className="space-y-0">
+            {recentPosts.map((post, index) => (
+              <div key={post.id}>
+                <Link href={`/blog/${post.id}`} className="group block py-4">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1.5">
+                    <time>{formatRelativeTime(post.date)}</time>
+                    {post.tags && post.tags.length > 0 && (
+                      <>
+                        <span className="text-border">/</span>
+                        <span>{post.tags[0]}</span>
+                      </>
+                    )}
+                  </div>
+                  <h3 className="text-sm font-medium group-hover:text-primary transition-colors mb-1">
+                    {post.title}
+                  </h3>
+                  {post.description && (
+                    <p className="text-xs text-muted-foreground line-clamp-1">
+                      {post.description}
+                    </p>
+                  )}
+                </Link>
+                {index < recentPosts.length - 1 && <Separator />}
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
     </main>
   )
 }

--- a/components/blog-list.tsx
+++ b/components/blog-list.tsx
@@ -123,11 +123,12 @@ export default function BlogList({ initialPosts }: BlogListProps) {
         <button
           onClick={() => setSelectedTag(null)}
           className={cn(
-            'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors',
+            'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
             selectedTag === null
-              ? 'bg-foreground text-background'
+              ? 'bg-foreground text-background ring-2 ring-foreground'
               : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
           )}
+          aria-pressed={selectedTag === null}
         >
           All
         </button>
@@ -136,16 +137,24 @@ export default function BlogList({ initialPosts }: BlogListProps) {
             key={tag}
             onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
             className={cn(
-              'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors',
+              'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               selectedTag === tag
-                ? 'bg-foreground text-background'
+                ? 'bg-foreground text-background ring-2 ring-foreground'
                 : 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
             )}
+            aria-pressed={selectedTag === tag}
           >
             {tag}
           </button>
         ))}
       </motion.div>
+
+      {/* Live region for screen readers */}
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {hasActiveFilters
+          ? `${filteredAndSortedPosts.length} result${filteredAndSortedPosts.length !== 1 ? 's' : ''} found`
+          : `${filteredAndSortedPosts.length} posts`}
+      </div>
 
       {/* Results count + clear */}
       {hasActiveFilters && (

--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -37,7 +37,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
       size="icon"
       onClick={handleCopy}
       className={cn(
-        'h-7 w-7 opacity-0 group-hover/code:opacity-100 transition-opacity',
+        'h-7 w-7 opacity-50 hover:opacity-100 focus-visible:opacity-100 transition-opacity',
         copied && 'opacity-100',
         className,
       )}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { motion } from 'motion/react'
+import { TypeAnimation } from 'react-type-animation'
+
+export function HeroSection() {
+  return (
+    <section className="flex flex-col items-center justify-center px-4 pt-32 pb-16">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-center max-w-xl"
+      >
+        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+          Eduardo Gaytan
+        </h1>
+        <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+          Senior software engineer focused on building fast, accessible, and well-crafted web applications. 8+ years across the full stack.
+        </p>
+        <div className="h-8 mb-6">
+          <TypeAnimation
+            sequence={[
+              'Building for the web',
+              2000,
+              'Shipping things that matter',
+              2000,
+              'Clean code, thoughtful design',
+              2000,
+            ]}
+            wrapper="p"
+            speed={50}
+            className="text-sm text-muted-foreground/70"
+            repeat={Number.POSITIVE_INFINITY}
+          />
+        </div>
+      </motion.div>
+    </section>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss'
+import { fontFamily } from 'tailwindcss/defaultTheme'
 
 const config: Config = {
   darkMode: ['class'],
@@ -17,6 +18,9 @@ const config: Config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['var(--font-geist-sans)', ...fontFamily.sans],
+      },
       colors: {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
- Fix Geist font: remove Arial override in globals.css, configure
  Tailwind font-sans to use the Geist CSS variable so the custom font
  actually renders
- Make code block copy button always visible (opacity-50 at rest) so
  it's discoverable on touch and keyboard, not just hover
- Add skip-to-content link for keyboard/screen-reader users
- Add prefers-reduced-motion media query to disable animations for
  users who need it
- Improve blog tag filter accessibility: add aria-pressed, focus-visible
  ring, and ring on active state so selection isn't color-only
- Add aria-live region for blog filter results so screen readers
  announce count changes
- Redesign home page: add personal intro, quick-link cards to About/
  Uses/Blog, and a recent posts section to replace the sparse
  title-only layout

https://claude.ai/code/session_0153gtY9QrT9WhfDLjERTdsA